### PR TITLE
Print the error on failure

### DIFF
--- a/tpmown/tpmown.go
+++ b/tpmown/tpmown.go
@@ -67,7 +67,7 @@ func main () {
 		err = tpm.TakeOwnership(srk)
 
 		if err != nil {
-			log.Fatalf("Unable to take ownership of TPM")
+			log.Fatalf("Unable to take ownership of TPM: %v", err)
 		}
 	}
 


### PR DESCRIPTION
Actually print the reason we fail to take ownership rather than just
asserting that we did
