### PR TITLE
Added methods to tspi needed to sign and verify hashes using TPM keys.

### DIFF
--- a/tspi/hash.go
+++ b/tspi/hash.go
@@ -17,10 +17,17 @@ package tspi
 // #include <trousers/tss.h>
 import "C"
 
+import (
+	"crypto"
+	"errors"
+	"unsafe"
+)
+
 // Hash is a TSS hash
 type Hash struct {
 	handle  C.TSS_HHASH
 	context C.TSS_HCONTEXT
+	hashAlg crypto.Hash
 }
 
 // Update updates a TSS hash with the data provided. It returns an error on
@@ -35,4 +42,47 @@ func (hash *Hash) Update(data []byte) error {
 func (hash *Hash) Verify(key *Key, signature []byte) error {
 	err := tspiError(C.Tspi_Hash_VerifySignature(hash.handle, key.handle, (C.UINT32)(len(signature)), (*C.BYTE)(&signature[0])))
 	return err
+}
+
+// https://golang.org/src/crypto/rsa/pkcs1v15.go#L204
+var hashPrefixes = map[crypto.Hash][]byte{
+	crypto.MD5:       {0x30, 0x20, 0x30, 0x0c, 0x06, 0x08, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x02, 0x05, 0x05, 0x00, 0x04, 0x10},
+	crypto.SHA1:      {0x30, 0x21, 0x30, 0x09, 0x06, 0x05, 0x2b, 0x0e, 0x03, 0x02, 0x1a, 0x05, 0x00, 0x04, 0x14},
+	crypto.SHA224:    {0x30, 0x2d, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x04, 0x05, 0x00, 0x04, 0x1c},
+	crypto.SHA256:    {0x30, 0x31, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x01, 0x05, 0x00, 0x04, 0x20},
+	crypto.SHA384:    {0x30, 0x41, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x02, 0x05, 0x00, 0x04, 0x30},
+	crypto.SHA512:    {0x30, 0x51, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x03, 0x05, 0x00, 0x04, 0x40},
+	crypto.MD5SHA1:   {}, // A special TLS case which doesn't use an ASN1 prefix.
+	crypto.RIPEMD160: {0x30, 0x20, 0x30, 0x08, 0x06, 0x06, 0x28, 0xcf, 0x06, 0x03, 0x00, 0x31, 0x04, 0x14},
+}
+
+// SetValue sets the value of the hash to the given bytes
+func (hash *Hash) SetValue(hashed []byte) error {
+	var data []byte
+	if hash.hashAlg == crypto.SHA1 {
+		data = hashed
+	} else {
+		prefix, ok := hashPrefixes[hash.hashAlg]
+		if !ok {
+			return errors.New("Unsupported hash algorithm.")
+		}
+		data = append(prefix, hashed...)
+	}
+
+	return tspiError(C.Tspi_Hash_SetHashValue(hash.handle, (C.UINT32)(len(data)), (*C.BYTE)(&data[0])))
+}
+
+// Sign uses the provided key to create a signature.
+func (hash *Hash) Sign(key *Key) ([]byte, error) {
+	var dataLen C.UINT32
+	var cData *C.BYTE
+	err := tspiError(C.Tspi_Hash_Sign(hash.handle, key.handle, &dataLen, &cData))
+	data := C.GoBytes(unsafe.Pointer(cData), (C.int)(dataLen))
+	C.Tspi_Context_FreeMemory(hash.context, cData)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
 }


### PR DESCRIPTION
Example of using the new methods to generate a key and perform a SHA256 hash/signature:

```
package main

import (
	"crypto"
	"crypto/rsa"
	"crypto/sha256"
	"crypto/x509"
	"encoding/base64"
	"fmt"
	"os"
	"github.com/coreos/go-tspi/tspi"
	"github.com/coreos/go-tspi/tspiconst"
)

func main() {
	// Create a new TSPI context
	context, err := tspi.NewContext()
	if err != nil {
		fmt.Fprintf(os.Stderr, "Error creating TSPI context: %s\n", err)
		return
	}
	defer context.Close()

	// Connect to the TPM daemon
	err = context.Connect()
	if err != nil {
		fmt.Fprintf(os.Stderr, "Error connecting to tpmd: %s\n", err)
		return
	}

	var wellKnownSecret [20]byte
	policy, err := context.CreatePolicy(tspiconst.TSS_OBJECT_TYPE_POLICY | tspiconst.TSS_POLICY_USAGE )
	policy.SetSecret(tspiconst.TSS_SECRET_MODE_SHA1, wellKnownSecret[:])

	srkKey, err := context.LoadKeyByUUID(tspiconst.TSS_PS_TYPE_SYSTEM, tspi.TSS_UUID_SRK)
	if err != nil {
		fmt.Fprintf(os.Stderr, "Error loading SRK: %s\n", err)
		return
	}
	srkKey.AssignPolicy(policy)

	newKey, err := context.CreateKey(tspiconst.TSS_OBJECT_TYPE_RSAKEY | tspiconst.TSS_KEY_TYPE_SIGNING | tspiconst.TSS_KEY_SIZE_2048 | tspiconst.TSS_KEY_NOT_MIGRATABLE | tspiconst.TSS_KEY_AUTHORIZATION)
	if err != nil {
		fmt.Fprintf(os.Stderr, "Error creating new key object: %s\n", err)
		return
	}
	newKey.AssignPolicy(policy)
	newKey.SetSignatureScheme(tspiconst.TSS_SS_RSASSAPKCS1V15_DER)

	err = newKey.GenerateKey(srkKey)
	if err != nil {
		fmt.Fprintf(os.Stderr, "Error generating key: %s\n", err)
		return
	}

	pubKeyBlob, err := newKey.GetPubKeyBlob()
	if err != nil {
		fmt.Fprintf(os.Stderr, "Error getting public key: %s\n", err)
		return
	}
	fmt.Printf("Public key blob: %s\n", base64.StdEncoding.EncodeToString(pubKeyBlob))

	keyBlob, err := newKey.GetKeyBlob()
	if err != nil {
		fmt.Fprintf(os.Stderr, "Error getting keyblob: %s\n", err)
		return
	}
	fmt.Printf("Key blob: %s\n", base64.StdEncoding.EncodeToString(keyBlob))

	pubKey, err := newKey.GetPublicKey()
	if err != nil {
		fmt.Fprintf(os.Stderr, "Error unmarshaling keyblob: %s\n", err)
		return
	}
	pubKeyBytes, err := x509.MarshalPKIXPublicKey(pubKey)
	if err != nil {
		fmt.Fprintf(os.Stderr, "Error marshaling public key: %s\n", err)
		return
	}
	fmt.Printf("Public key: %s\n", base64.StdEncoding.EncodeToString(pubKeyBytes))


	// Load key
	newKey, err = context.LoadKeyByBlob(srkKey, keyBlob)
	if err != nil {
		fmt.Fprintf(os.Stderr, "Error loading key from keyblob: %s\n", err)
		return
	}
	newKey.AssignPolicy(policy)

	hashed := sha256.Sum256([]byte("Hello, World!"))
	hash, err := context.CreateHash(crypto.SHA256)
	if err != nil {
		fmt.Fprintf(os.Stderr, "Error creating hash object: %s\n", err)
		return
	}
	err = hash.SetValue(hashed[:])
	if err != nil {
		fmt.Fprintf(os.Stderr, "Error setting hash value: %s\n", err)
		return
	}

	signature, err := hash.Sign(newKey)
	if err != nil {
		fmt.Fprintf(os.Stderr, "Error signing hash: %s\n", err)
		return
	}
	fmt.Printf("Signature: %s\n", base64.StdEncoding.EncodeToString(signature))

	err = rsa.VerifyPKCS1v15(pubKey, crypto.SHA256, hashed[:], signature)
	if err != nil {
		fmt.Fprintf(os.Stderr, "Error verifying signature: %s\n", err)
		return
	}
	fmt.Printf("Signature verification successful.\n")
}
```