### PR TITLE
Added Close() to the various go-tspi structs.

### DIFF
--- a/tspi/hash.go
+++ b/tspi/hash.go
@@ -86,3 +86,9 @@ func (hash *Hash) Sign(key *Key) ([]byte, error) {
 
 	return data, nil
 }
+
+// Close closes the Hash object.
+func (hash *Hash) Close() error {
+	err := tspiError(C.Tspi_Context_CloseObject(hash.context, hash.handle))
+	return err
+}

--- a/tspi/key.go
+++ b/tspi/key.go
@@ -269,3 +269,9 @@ func (key *Key) AssignPolicy(policy *Policy) error {
 	err := tspiError(C.Tspi_Policy_AssignToObject(policy.handle, (C.TSS_HOBJECT)(key.handle)))
 	return err
 }
+
+// Close closes the Key object.
+func (key *Key) Close() error {
+	err := tspiError(C.Tspi_Context_CloseObject(key.context, key.handle))
+	return err
+}

--- a/tspi/nv.go
+++ b/tspi/nv.go
@@ -42,3 +42,9 @@ func (nv *NV) AssignPolicy(policy *Policy) error {
 	err := tspiError(C.Tspi_Policy_AssignToObject(policy.handle, (C.TSS_HOBJECT)(nv.handle)))
 	return err
 }
+
+// Close closes the NV object.
+func (nv *NV) Close() error {
+	err := tspiError(C.Tspi_Context_CloseObject(nv.context, nv.handle))
+	return err
+}

--- a/tspi/pcrs.go
+++ b/tspi/pcrs.go
@@ -59,3 +59,9 @@ func (pcrs *PCRs) GetPCRValues() ([][]byte, error) {
 	}
 	return pcrs.pcrs[:], nil
 }
+
+// Close closes the PCRs object.
+func (pcrs *PCRs) Close() error {
+	err := tspiError(C.Tspi_Context_CloseObject(pcrs.context, pcrs.handle))
+	return err
+}

--- a/tspi/policy.go
+++ b/tspi/policy.go
@@ -29,3 +29,9 @@ func (policy *Policy) SetSecret(sectype int, secret []byte) error {
 	err := tspiError(C.Tspi_Policy_SetSecret(policy.handle, (C.TSS_FLAG)(sectype), (C.UINT32)(len(secret)), (*C.BYTE)(&secret[0])))
 	return err
 }
+
+// Close closes the Policy object.
+func (policy *Policy) Close() error {
+	err := tspiError(C.Tspi_Context_CloseObject(policy.context, policy.handle))
+	return err
+}

--- a/tspi/tpm.go
+++ b/tspi/tpm.go
@@ -222,3 +222,9 @@ func (tpm *TPM) CollateIdentityRequest(srk *Key, pubkey *Key, aik *Key) ([]byte,
 	C.Tspi_Context_FreeMemory(tpm.context, cCertReq)
 	return certReq, err
 }
+
+// Close closes the TPM object.
+func (tpm *TPM) Close() error {
+	err := tspiError(C.Tspi_Context_CloseObject(tpm.context, tpm.handle))
+	return err
+}


### PR DESCRIPTION
We typically do not expect to use Close() since our sessions are
relatively short--upon Closing the Context all associated objects
are closed anyway.
Also added GetCapability() to context.