### PR TITLE
Attestation

### DIFF
--- a/attestation/attestation.go
+++ b/attestation/attestation.go
@@ -37,12 +37,11 @@ func pad(plaintext []byte, bsize int) ([]byte, error) {
 }
 
 // AIKChallengeResponse takes the output from GenerateChallenge along with the
-// encrypted AIK key blob. The TPM then decrypts the asymmetric challenge with
-// its EK in order to obtain the AES key, and uses the AES key to decrypt the
-// symmetrically encrypted data. It verifies that this data blob corresponds
-// to the AIK it was given, and if so hands back the secret contained within
-// the symmetrically encrypted data.
-func AIKChallengeResponse(context *tspi.Context, aikblob []byte, asymchallenge []byte, symchallenge []byte) (secret []byte, err error) {
+// AIK. The TPM then decrypts the asymmetric challenge with its EK in order to
+// obtain the AES key, and uses the AES key to decrypt the symmetrically encrypted
+// data. It verifies that this data blob corresponds to the AIK it was given, and
+// if so hands back the secret contained within the symmetrically encrypted data.
+func AIKChallengeResponse(context *tspi.Context, aik *tspi.Key, asymchallenge []byte, symchallenge []byte) (secret []byte, err error) {
 	var wellKnown [20]byte
 
 	srk, err := context.LoadKeyByUUID(tspiconst.TSS_PS_TYPE_SYSTEM, tspi.TSS_UUID_SRK)
@@ -63,10 +62,6 @@ func AIKChallengeResponse(context *tspi.Context, aikblob []byte, asymchallenge [
 	tpm.AssignPolicy(tpmpolicy)
 	tpmpolicy.SetSecret(tspiconst.TSS_SECRET_MODE_SHA1, wellKnown[:])
 
-	aik, err := context.LoadKeyByBlob(srk, aikblob)
-	if err != nil {
-		return nil, err
-	}
 	secret, err = tpm.ActivateIdentity(aik, asymchallenge, symchallenge)
 
 	return secret, err

--- a/attestation/attestation.go
+++ b/attestation/attestation.go
@@ -73,9 +73,9 @@ func AIKChallengeResponse(context *tspi.Context, aikblob []byte, asymchallenge [
 }
 
 // CreateAIK asks the TPM to generate an Attestation Identity Key. It returns
-// the unencrypted public half of the AIK along with an encrypted blob
-// containing both halves of the key, and any error.
-func CreateAIK(context *tspi.Context) ([]byte, []byte, error) {
+// the tspi.Key struct the unencrypted public half of the AIK along with an
+// encrypted blob containing both halves of the key, and any error.
+func CreateAIK(context *tspi.Context) (*tspi.Key, []byte, []byte, error) {
 	var wellKnown [20]byte
 	n := make([]byte, 2048/8)
 	for i := 0; i < 2048/8; i++ {
@@ -84,61 +84,54 @@ func CreateAIK(context *tspi.Context) ([]byte, []byte, error) {
 
 	srk, err := context.LoadKeyByUUID(tspiconst.TSS_PS_TYPE_SYSTEM, tspi.TSS_UUID_SRK)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	keypolicy, err := srk.GetPolicy(tspiconst.TSS_POLICY_USAGE)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
-	err = keypolicy.SetSecret(tspiconst.TSS_SECRET_MODE_SHA1, wellKnown[:])
-	if err != nil {
-		return nil, nil, err
+	if err = keypolicy.SetSecret(tspiconst.TSS_SECRET_MODE_SHA1, wellKnown[:]); err != nil {
+		return nil, nil, nil, err
 	}
 
 	tpm := context.GetTPM()
 	tpmpolicy, err := tpm.GetPolicy(tspiconst.TSS_POLICY_USAGE)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
-	err = tpm.AssignPolicy(tpmpolicy)
-	if err != nil {
-		return nil, nil, err
-	}
-	err = tpmpolicy.SetSecret(tspiconst.TSS_SECRET_MODE_SHA1, wellKnown[:])
-	if err != nil {
-		return nil, nil, err
+	if err = tpmpolicy.SetSecret(tspiconst.TSS_SECRET_MODE_SHA1, wellKnown[:]); err != nil {
+		return nil, nil, nil, err
 	}
 
 	pcakey, err := context.CreateKey(tspiconst.TSS_KEY_TYPE_LEGACY | tspiconst.TSS_KEY_SIZE_2048)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
-	err = pcakey.SetModulus(n)
-	if err != nil {
-		return nil, nil, err
+	if err = pcakey.SetModulus(n); err != nil {
+		return nil, nil, nil, err
 	}
 
 	aik, err := context.CreateKey(tspiconst.TSS_KEY_TYPE_IDENTITY | tspiconst.TSS_KEY_SIZE_2048)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	_, err = tpm.CollateIdentityRequest(srk, pcakey, aik)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	pubkey, err := aik.GetPubKeyBlob()
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	blob, err := aik.GetKeyBlob()
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	_, err = aik.GetModulus()
-	return pubkey, blob, nil
+	return aik, pubkey, blob, nil
 }
 
 // GetEKCert reads the Endorsement Key certificate from the TPM's NVRAM and


### PR DESCRIPTION
Changes to tspi/attestation in order to return and use *tspi.Key instead of passing around blobs and then loading the handle with the blob