### PR TITLE
Fix for issue #9 for 32-bit architectures

### DIFF
--- a/tspi/tpm.go
+++ b/tspi/tpm.go
@@ -89,7 +89,7 @@ func (tpm *TPM) GetEventLog() ([]tspiconst.Log, error) {
 	}
 
 	length := count * C.UINT32(unsafe.Sizeof(event))
-	slice := (*[1 << 30]C.TSS_PCR_EVENT)(unsafe.Pointer(events))[:length:length]
+	slice := (*[1 << 26]C.TSS_PCR_EVENT)(unsafe.Pointer(events))[:length:length]
 
 	for i := 0; i < int(count); i++ {
 		var entry tspiconst.Log


### PR DESCRIPTION
The target host is a 32-bit Debian 9 on Armv7 Cortex-A7 dual-core 1 GHz using the official golang v.14 ARMv6l build. Anything over the value 26 was resulting in issue #9. Was able to compile and work normally. However, since I don't have access to a TPM1.2 device but a TPM2.0, the file /sys/kernel/security/tpm0/binary_bios_measurements does not exist for me and therefore not able to verify behavior.